### PR TITLE
refactor: 엔티티에서 Serializable 제거

### DIFF
--- a/src/main/java/com/dgmoonlabs/psythinktank/domain/member/model/Authority.java
+++ b/src/main/java/com/dgmoonlabs/psythinktank/domain/member/model/Authority.java
@@ -4,7 +4,6 @@ import com.dgmoonlabs.psythinktank.global.constant.Role;
 import lombok.*;
 
 import javax.persistence.*;
-import java.io.Serializable;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -12,7 +11,7 @@ import java.io.Serializable;
 @Builder
 @Getter
 @Setter
-public class Authority implements Serializable {
+public class Authority {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/dgmoonlabs/psythinktank/domain/member/model/Member.java
+++ b/src/main/java/com/dgmoonlabs/psythinktank/domain/member/model/Member.java
@@ -7,7 +7,6 @@ import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 
 import javax.persistence.*;
-import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.Set;
 
@@ -16,7 +15,7 @@ import java.util.Set;
 @AllArgsConstructor
 @Builder
 @Getter
-public class Member extends BaseEntity implements Serializable {
+public class Member extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;


### PR DESCRIPTION
다른 객체들과 통일성위해 삭제
JPA 표준 스펙상으로는 구현하는 게 맞지만 실무적으로는 잘 안 하므로 제거