### PR TITLE
chore: HTML 타이틀 수정

### DIFF
--- a/src/main/resources/templates/viewStock.mustache
+++ b/src/main/resources/templates/viewStock.mustache
@@ -2,7 +2,7 @@
 <html>
 <head>
     {{>common/meta}}
-    <title>{{stock.name}}({{stock.symbol}}) - {{stock.overview}}</title>
+    <title>{{stock.name}}({{stock.symbol}}) - {{stock.corporationClass}}</title>
     {{>common/link}}
     {{>common/script}}
     {{>common/toast-ui}}


### PR DESCRIPTION
너무 긴 기업 개요 대신 기업 구분으로 변경