### PR TITLE
fix: 리소스 번들 메시지 소스 베이스네임 변경

### DIFF
--- a/src/main/java/com/dgmoonlabs/psythinktank/global/config/WebConfig.java
+++ b/src/main/java/com/dgmoonlabs/psythinktank/global/config/WebConfig.java
@@ -26,7 +26,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Bean
     public MessageSource messageSource() {
         ReloadableResourceBundleMessageSource messageSource = new ReloadableResourceBundleMessageSource();
-        messageSource.setBasename("messages");
+        messageSource.setBasename("classpath:/messages");
         messageSource.setDefaultEncoding("UTF-8");
         return messageSource;
     }


### PR DESCRIPTION
ReloadableResourceBundleMessageSource의 경우 basename이 classname:/으로 시작